### PR TITLE
feat: add search API

### DIFF
--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,0 +1,103 @@
+import { ytSearch, ytVideos } from "@/lib/yt";
+
+export const runtime = "edge";
+
+interface Result {
+  videoId: string;
+  title: string;
+  channelTitle: string;
+  thumbnailUrl: string;
+  youtubeUrl: string;
+  publishedAt: string;
+  durationSeconds: number;
+  viewCount: number;
+}
+
+const cache = new Map<string, { ts: number; data: Result[] }>();
+const TTL = 120_000;
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json();
+    const queries: string[] = Array.isArray(body?.queries) ? body.queries : [];
+    if (!queries.length) throw new Error("invalid");
+
+    const key = JSON.stringify(queries);
+    const now = Date.now();
+    const cached = cache.get(key);
+    if (cached && now - cached.ts < TTL) {
+      return new Response(JSON.stringify({ results: cached.data }), {
+        headers: { "content-type": "application/json" },
+      });
+    }
+
+    const searchLists = await Promise.all(queries.map((q) => ytSearch(q, 15)));
+    const infoMap = new Map<string, Result>();
+    for (const list of searchLists) {
+      for (const item of list) {
+        if (infoMap.size >= 60) break;
+        if (!infoMap.has(item.videoId)) {
+          infoMap.set(item.videoId, {
+            videoId: item.videoId,
+            title: item.title,
+            channelTitle: item.channelTitle,
+            thumbnailUrl: item.thumbnailUrl,
+            youtubeUrl: `https://www.youtube.com/watch?v=${item.videoId}`,
+            publishedAt: item.publishedAt,
+            durationSeconds: 0,
+            viewCount: 0,
+          });
+        }
+      }
+      if (infoMap.size >= 60) break;
+    }
+
+    const ids = Array.from(infoMap.keys());
+    const stats = await ytVideos(ids);
+    for (const s of stats) {
+      const item = infoMap.get(s.videoId);
+      if (item) {
+        item.durationSeconds = s.durationSeconds;
+        item.viewCount = s.viewCount;
+      }
+    }
+
+    const baseScores = ids.map((id) => {
+      const v = infoMap.get(id)!;
+      const publishedMs = Date.parse(v.publishedAt);
+      const ageDays = isNaN(publishedMs)
+        ? 0
+        : (now - publishedMs) / 86_400_000;
+      const base =
+        Math.log10(v.viewCount + 1) +
+        Math.exp(-ageDays / 60) * 0.5 +
+        (v.durationSeconds >= 600 ? 0.2 : 0);
+      return { v, base };
+    });
+
+    baseScores.sort((a, b) => b.base - a.base);
+
+    const channelCounts = new Map<string, number>();
+    const scored: { v: Result; score: number }[] = [];
+    for (const { v, base } of baseScores) {
+      const count = channelCounts.get(v.channelTitle) ?? 0;
+      const score = base - 0.2 * count;
+      channelCounts.set(v.channelTitle, count + 1);
+      scored.push({ v, score });
+    }
+
+    scored.sort((a, b) => b.score - a.score);
+    const top = scored.slice(0, 12).map((s) => s.v);
+
+    cache.set(key, { ts: now, data: top });
+
+    return new Response(JSON.stringify({ results: top }), {
+      headers: { "content-type": "application/json" },
+    });
+  } catch {
+    return new Response(JSON.stringify({ results: [] }), {
+      headers: { "content-type": "application/json" },
+    });
+  }
+}
+


### PR DESCRIPTION
## Summary
- add YouTube search API route with scoring and caching

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/openai)*

------
https://chatgpt.com/codex/tasks/task_e_68c434a022608333aafc9eb1fb28bad9