### PR TITLE
feat: show up to 30 video results

### DIFF
--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -15,6 +15,7 @@ interface Result {
 
 const cache = new Map<string, { ts: number; data: Result[] }>();
 const TTL = 120_000;
+const RESULTS_LIMIT = 30;
 
 function jitter(id: string, seed: number): number {
   let h = seed;
@@ -106,7 +107,7 @@ export async function POST(req: Request) {
     }
 
     scored.sort((a, b) => b.score - a.score);
-    const top = scored.slice(0, 12).map((s) => s.v);
+    const top = scored.slice(0, RESULTS_LIMIT).map((s) => s.v);
 
     if (!excludeIds.length && seed === undefined) {
       cache.set(key, { ts: now, data: top });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,6 +11,7 @@ interface Item {
 }
 
 const refinements = ["weirder", "newer", "longer"] as const;
+const RESULTS_LIMIT = 30;
 
 export default function Home() {
   const [prompt, setPrompt] = useState("");
@@ -71,8 +72,8 @@ export default function Home() {
   return (
     <div className="min-h-screen flex flex-col">
       <main className="flex-1 p-4">
-        <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 md:grid-cols-3">
-          {items.map((it) => (
+        <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+          {items.slice(0, RESULTS_LIMIT).map((it) => (
             <a
               key={it.videoId}
               href={it.youtubeUrl}


### PR DESCRIPTION
## Summary
- return up to 30 videos in search API via new `RESULTS_LIMIT`
- render up to 30 cards on home page and support four-column layout on large screens

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/openai)*

------
https://chatgpt.com/codex/tasks/task_e_68c4c1f46fa48333834f11f985546570