### PR TITLE
feat: add watch later list

### DIFF
--- a/src/app/later/page.tsx
+++ b/src/app/later/page.tsx
@@ -1,0 +1,67 @@
+"use client";
+import { useEffect, useState } from "react";
+import { listLater, removeLater, type LaterItem } from "@/lib/later";
+
+export default function LaterPage() {
+  const [items, setItems] = useState<LaterItem[]>([]);
+
+  useEffect(() => {
+    setItems(listLater());
+  }, []);
+
+  return (
+    <main className="min-h-screen bg-white text-slate-900">
+      <header className="p-4 text-xl font-semibold flex items-center justify-between">
+        <a href="/" className="text-orange-500">Bloom</a>
+        <span className="text-sm text-slate-600">Watch Later</span>
+      </header>
+
+      <div className="max-w-5xl mx-auto px-4 pb-10">
+        {items.length === 0 && (
+          <div className="text-sm text-slate-500 mt-6">
+            Nothing saved. Use “🔖 Save” on any card.
+          </div>
+        )}
+
+        <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 mt-6">
+          {items.map((it) => (
+            <a
+              key={it.videoId}
+              href={it.youtubeUrl}
+              target="_blank"
+              rel="noreferrer"
+              className={[
+                "relative bg-white border border-slate-200 rounded-xl overflow-hidden shadow-sm",
+                "hover:shadow-md transition",
+              ].join(" ")}
+            >
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.preventDefault();
+                  removeLater(it.videoId);
+                  setItems(listLater());
+                }}
+                className="absolute right-2 top-2 rounded-full px-2.5 py-1.5 text-xs font-semibold bg-slate-200 text-slate-700 hover:bg-slate-300"
+                aria-label="Remove"
+              >
+                Remove
+              </button>
+
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img alt={it.title} src={it.thumbnailUrl} className="w-full aspect-video object-cover" />
+              <div className="p-3">
+                <div className="text-xs text-slate-500">
+                  Saved {new Date(it.savedAt).toLocaleString()}
+                </div>
+                <div className="text-sm text-slate-500">{it.channelTitle}</div>
+                <div className="font-medium mt-1 line-clamp-2">{it.title}</div>
+              </div>
+            </a>
+          ))}
+        </div>
+      </div>
+    </main>
+  );
+}
+

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -27,6 +27,15 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
+        <header className="p-4 text-xl font-semibold flex items-center justify-between">
+          <a href="/" className="text-orange-500">Bloom</a>
+          <a
+            href="/later"
+            className="text-sm font-normal text-slate-600 hover:text-slate-900 underline underline-offset-4"
+          >
+            Watch Later
+          </a>
+        </header>
         {children}
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useRef } from "react";
+import { addLater, isLater } from "@/lib/later";
 
 interface Item {
   videoId: string;
@@ -116,8 +117,32 @@ export default function Home() {
               href={it.youtubeUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="flex flex-col"
+              className={[
+                "relative flex flex-col",
+                "bg-white border border-slate-200 rounded-xl overflow-hidden shadow-sm",
+                "hover:shadow-md transition",
+              ].join(" ")}
             >
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.preventDefault();
+                  addLater({
+                    videoId: it.videoId,
+                    title: it.title,
+                    channelTitle: it.channelTitle,
+                    thumbnailUrl: it.thumbnailUrl,
+                    youtubeUrl: it.youtubeUrl,
+                  });
+                  // Force a re-render so isLater() reflects immediately
+                  setItems((cur) => [...cur]);
+                }}
+                aria-label={isLater(it.videoId) ? "Saved" : "Save to Watch Later"}
+                className={`absolute right-2 top-2 rounded-full px-2.5 py-1.5 text-xs font-semibold shadow
+    ${isLater(it.videoId) ? "bg-slate-700 text-white" : "bg-orange-500 text-white hover:bg-orange-600"}`}
+              >
+                {isLater(it.videoId) ? "✓ Saved" : "🔖 Save"}
+              </button>
               <img
                 src={it.thumbnailUrl}
                 alt={it.title}

--- a/src/lib/later.ts
+++ b/src/lib/later.ts
@@ -1,0 +1,48 @@
+export type LaterItem = {
+  videoId: string;
+  title: string;
+  channelTitle: string;
+  thumbnailUrl: string;
+  youtubeUrl: string;
+  savedAt: string; // ISO
+};
+
+const KEY = "bloom.watchlater.v1";
+
+function safeRead(): LaterItem[] {
+  try {
+    const raw = localStorage.getItem(KEY);
+    if (!raw) return [];
+    const arr = JSON.parse(raw);
+    return Array.isArray(arr) ? arr : [];
+  } catch {
+    return [];
+  }
+}
+
+function safeWrite(items: LaterItem[]) {
+  try {
+    localStorage.setItem(KEY, JSON.stringify(items));
+  } catch {}
+}
+
+export function listLater(): LaterItem[] {
+  return safeRead();
+}
+
+export function isLater(videoId: string): boolean {
+  return safeRead().some((x) => x.videoId === videoId);
+}
+
+export function addLater(item: Omit<LaterItem, "savedAt">): boolean {
+  const cur = safeRead();
+  if (cur.some((x) => x.videoId === item.videoId)) return false;
+  const next: LaterItem[] = [{ ...item, savedAt: new Date().toISOString() }, ...cur];
+  safeWrite(next);
+  return true;
+}
+
+export function removeLater(videoId: string) {
+  safeWrite(safeRead().filter((x) => x.videoId !== videoId));
+}
+


### PR DESCRIPTION
## Summary
- add localStorage-based storage helpers for watch later
- overlay save button on video cards and re-render state
- new /later page listing saved items with remove option
- header link to watch later page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc'; `npm install` 403 for openai)*

------
https://chatgpt.com/codex/tasks/task_e_68c5693421bc8333b0b617ea0c91d327