### PR TITLE
feat: add minimal diagnostics and health endpoint

### DIFF
--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,8 +1,45 @@
+import { NextRequest, NextResponse } from "next/server";
+
 export const runtime = "edge";
 
-export async function GET() {
-  return new Response(
-    JSON.stringify({ ok: true, ts: Date.now() }),
-    { headers: { "content-type": "application/json" } }
-  );
+export async function GET(_req: NextRequest) {
+  const OPENAI = !!process.env.OPENAI_API_KEY;
+  const YT = process.env.YOUTUBE_API_KEY || "";
+  const ytPresent = !!YT;
+
+  let ytStatus: number | null = null;
+  let ytBody: any = null;
+
+  if (ytPresent) {
+    try {
+      const url = new URL("https://www.googleapis.com/youtube/v3/search");
+      url.searchParams.set("part", "snippet");
+      url.searchParams.set("q", "test");
+      url.searchParams.set("type", "video");
+      url.searchParams.set("maxResults", "1");
+      url.searchParams.set("key", YT);
+
+      const res = await fetch(url.toString(), { method: "GET" });
+      ytStatus = res.status;
+      try {
+        ytBody = await res.json();
+      } catch {
+        ytBody = await res.text();
+      }
+    } catch (err) {
+      ytStatus = -1;
+      ytBody = { error: (err as Error)?.message || String(err) };
+    }
+  }
+
+  return NextResponse.json({
+    env: {
+      OPENAI_API_KEY_present: OPENAI,
+      YOUTUBE_API_KEY_present: ytPresent,
+    },
+    youtubeProbe: ytPresent
+      ? { status: ytStatus, body: ytBody }
+      : { status: null, body: "No YOUTUBE_API_KEY" },
+  });
 }
+

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -100,6 +100,7 @@ export default function Home() {
     if (e.nativeEvent.isComposing || loading) return;
 
     if (e.key === "Enter" && !e.shiftKey) {
+      if (!q.trim()) return; // avoid empty searches that yield 400/empty results
       e.preventDefault();
       // "dirty" means q !== lastPromptRef.current
       const dirty = q.trim() !== lastPromptRef.current.trim();


### PR DESCRIPTION
## Summary
- log YouTube API errors for easier debugging
- expose /api/health to verify env keys and a test search
- block empty Enter submits in search input

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68c56bd7949c83339a0845757301925e