### PR TITLE
Implement query caching and rate limiting

### DIFF
--- a/src/app/api/_cache.ts
+++ b/src/app/api/_cache.ts
@@ -1,0 +1,36 @@
+export interface Result {
+  videoId: string;
+  title: string;
+  channelTitle: string;
+  thumbnailUrl: string;
+  youtubeUrl: string;
+  publishedAt: string;
+  durationSeconds: number;
+  viewCount: number;
+}
+
+const TTL = 24 * 60 * 60 * 1000; // 24h
+const MAX_KEYS = 5000;
+
+const cache = new Map<string, { ts: number; data: Result[] }>();
+
+export function cacheGet(key: string): Result[] | undefined {
+  const entry = cache.get(key);
+  if (!entry) return undefined;
+  if (Date.now() - entry.ts > TTL) {
+    cache.delete(key);
+    return undefined;
+  }
+  // refresh for LRU
+  cache.delete(key);
+  cache.set(key, entry);
+  return entry.data;
+}
+
+export function cacheSet(key: string, data: Result[]): void {
+  cache.set(key, { ts: Date.now(), data });
+  if (cache.size > MAX_KEYS) {
+    const oldestKey = cache.keys().next().value as string | undefined;
+    if (oldestKey !== undefined) cache.delete(oldestKey);
+  }
+}

--- a/src/app/api/_ratelimit.ts
+++ b/src/app/api/_ratelimit.ts
@@ -1,0 +1,28 @@
+const WINDOW = 60 * 1000; // 60 seconds
+const MAX_TOKENS = 10;
+
+interface Bucket {
+  tokens: number;
+  ts: number;
+}
+
+const buckets = new Map<string, Bucket>();
+
+export function rateLimit(key: string): boolean {
+  const now = Date.now();
+  const bucket = buckets.get(key);
+  if (!bucket) {
+    buckets.set(key, { tokens: MAX_TOKENS - 1, ts: now });
+    return false;
+  }
+  if (now - bucket.ts > WINDOW) {
+    bucket.tokens = MAX_TOKENS - 1;
+    bucket.ts = now;
+    return false;
+  }
+  if (bucket.tokens <= 0) {
+    return true;
+  }
+  bucket.tokens -= 1;
+  return false;
+}


### PR DESCRIPTION
## Summary
- add 24h in-memory LRU cache for search results
- introduce token-bucket rate limiter per client
- integrate caching and rate limiting into search endpoint

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/openai)*

------
https://chatgpt.com/codex/tasks/task_e_68c57419710c833397ea26996d981d8b