### PR TITLE
Add rate limiting to search API

### DIFF
--- a/src/app/api/_ratelimit.ts
+++ b/src/app/api/_ratelimit.ts
@@ -1,0 +1,23 @@
+// Window: 60s; Max: 10 requests per IP (process memory only)
+const WINDOW_MS = 60_000;
+const MAX = 10;
+type Bucket = { ts: number[] };
+const buckets = new Map<string, Bucket>();
+
+export function rateLimited(ip: string): boolean {
+  const now = Date.now();
+  const b = buckets.get(ip) ?? { ts: [] };
+  b.ts = b.ts.filter(t => now - t < WINDOW_MS);
+  if (b.ts.length >= MAX) { buckets.set(ip, b); return true; }
+  b.ts.push(now); buckets.set(ip, b); return false;
+}
+
+export function rateHeaders(ip: string) {
+  const b = buckets.get(ip) ?? { ts: [] };
+  const remaining = Math.max(0, MAX - b.ts.length);
+  return {
+    "X-RateLimit-Limit": String(MAX),
+    "X-RateLimit-Remaining": String(remaining),
+    "X-RateLimit-Window": `${WINDOW_MS}ms`,
+  };
+}


### PR DESCRIPTION
## Summary
- add in-memory token-bucket rate limiter and rate-limit headers
- apply rate limiting to search API and return 429 when exceeded

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68c5bfd8f3ac8333a500dde2add35ce0