### PR TITLE
feat: standardize saved library usage

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef } from "react";
 import { useRouter } from "next/navigation";
-import { addLater, isLater } from "@/lib/later";
+import { isSaved, toggleSave } from "@/lib/library";
 
 interface Item {
   videoId: string;
@@ -137,50 +137,53 @@ export default function Home() {
             </div>
           )}
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-            {items.slice(0, RESULTS_LIMIT).map((it) => (
-              <a
-                key={it.videoId}
-                href={it.youtubeUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="relative rounded-2xl shadow-sm border border-slate-200 overflow-hidden hover:shadow-md transition"
-              >
-                <div className="aspect-video overflow-hidden relative">
-                  <img
-                    src={it.thumbnailUrl}
-                    alt={it.title}
-                    className="w-full h-full object-cover"
-                  />
-                  <button
-                    type="button"
-                    onClick={(e) => {
-                      e.preventDefault();
-                      addLater({
-                        videoId: it.videoId,
-                        title: it.title,
-                        channelTitle: it.channelTitle,
-                        thumbnailUrl: it.thumbnailUrl,
-                        youtubeUrl: it.youtubeUrl,
-                      });
-                      // Force a re-render so isLater() reflects immediately
-                      setItems((cur) => [...cur]);
-                    }}
-                    aria-label={isLater(it.videoId) ? "Saved" : "Save to Watch Later"}
-                    className={`absolute right-2 top-2 rounded-full px-2.5 py-1.5 text-xs font-semibold shadow ${
-                      isLater(it.videoId)
-                        ? "bg-slate-700 text-white"
-                        : "bg-orange-500 text-white hover:bg-orange-600"
-                    }`}
-                  >
-                    {isLater(it.videoId) ? "✓ Saved" : "🔖 Save"}
-                  </button>
-                </div>
-                <div className="p-4">
-                  <div className="text-sm font-medium">{it.title}</div>
-                  <div className="text-xs text-gray-500">{it.channelTitle}</div>
-                </div>
-              </a>
-            ))}
+            {items.slice(0, RESULTS_LIMIT).map((it) => {
+              const savedNow = isSaved(it.videoId);
+              return (
+                <a
+                  key={it.videoId}
+                  href={it.youtubeUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="relative rounded-2xl shadow-sm border border-slate-200 overflow-hidden hover:shadow-md transition"
+                >
+                  <div className="aspect-video overflow-hidden relative">
+                    <img
+                      src={it.thumbnailUrl}
+                      alt={it.title}
+                      className="w-full h-full object-cover"
+                    />
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        toggleSave({
+                          videoId: it.videoId,
+                          title: it.title,
+                          channelTitle: it.channelTitle,
+                          youtubeUrl: it.youtubeUrl,
+                          thumbnailUrl: it.thumbnailUrl,
+                        });
+                        // Force a re-render so isSaved() reflects immediately
+                        setItems((cur) => [...cur]);
+                      }}
+                      aria-label={savedNow ? "Saved" : "Save to Watch Later"}
+                      className={`absolute right-2 top-2 rounded-full px-2.5 py-1.5 text-xs font-semibold shadow ${
+                        savedNow
+                          ? "bg-slate-700 text-white"
+                          : "bg-orange-500 text-white hover:bg-orange-600"
+                      }`}
+                    >
+                      {savedNow ? "✓ Saved" : "Save"}
+                    </button>
+                  </div>
+                  <div className="p-4">
+                    <div className="text-sm font-medium">{it.title}</div>
+                    <div className="text-xs text-gray-500">{it.channelTitle}</div>
+                  </div>
+                </a>
+              );
+            })}
           </div>
         </div>
       </main>

--- a/src/app/saved/page.tsx
+++ b/src/app/saved/page.tsx
@@ -1,11 +1,7 @@
 "use client";
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-
-type SavedItem = {
-  videoId: string; title: string; channelTitle?: string;
-  youtubeUrl: string; thumbnailUrl: string; savedAt?: number;
-};
+import { loadLibrary, SavedItem } from "@/lib/library";
 
 function buildDeck(list: SavedItem[], need = 8) {
   const out: SavedItem[] = []; if (!list.length) return out;
@@ -20,12 +16,9 @@ function buildDeck(list: SavedItem[], need = 8) {
 export default function SavedPage() {
   const [items, setItems] = useState<SavedItem[]>([]);
   useEffect(() => {
-    try {
-      const raw = localStorage.getItem("watchLater") || "[]";
-      const parsed: SavedItem[] = JSON.parse(raw);
-      parsed.sort((a,b) => (b.savedAt ?? 0) - (a.savedAt ?? 0));
-      setItems(parsed);
-    } catch { setItems([]); }
+    const lib = loadLibrary();
+    lib.sort((a, b) => (b.savedAt ?? 0) - (a.savedAt ?? 0));
+    setItems(lib);
   }, []);
   const deck = useMemo(() => buildDeck(items, 8), [items]);
 

--- a/src/lib/library.ts
+++ b/src/lib/library.ts
@@ -1,0 +1,77 @@
+// Client-only helpers for the Saved Library
+export type SavedItem = {
+  videoId: string;
+  title: string;
+  channelTitle?: string;
+  youtubeUrl: string;
+  thumbnailUrl: string;
+  savedAt?: number;
+};
+
+const LIB_KEY = "watchLater";
+
+function read(): SavedItem[] {
+  try {
+    const raw = localStorage.getItem(LIB_KEY) || "[]";
+    const arr = JSON.parse(raw);
+    if (!Array.isArray(arr)) return [];
+    // normalize older/minimal entries
+    return arr
+      .filter(Boolean)
+      .map((v: any) => ({
+        videoId: String(v.videoId ?? v.id ?? ""),
+        title: String(v.title ?? v.snippet?.title ?? v.name ?? ""),
+        channelTitle:
+          v.channelTitle ?? v.snippet?.channelTitle ?? v.author ?? undefined,
+        youtubeUrl:
+          v.youtubeUrl ??
+          (v.videoId ? `https://www.youtube.com/watch?v=${v.videoId}` : ""),
+        thumbnailUrl:
+          v.thumbnailUrl ??
+          (v.videoId ? `https://i.ytimg.com/vi/${v.videoId}/mqdefault.jpg` : ""),
+        savedAt: typeof v.savedAt === "number" ? v.savedAt : 0,
+      }))
+      .filter((v: SavedItem) => v.videoId);
+  } catch {
+    return [];
+  }
+}
+
+function write(items: SavedItem[]) {
+  localStorage.setItem(LIB_KEY, JSON.stringify(items));
+}
+
+export function loadLibrary(): SavedItem[] {
+  return read();
+}
+
+export function isSaved(videoId: string): boolean {
+  return read().some((v) => v.videoId === videoId);
+}
+
+export function saveVideo(item: SavedItem) {
+  const cur = read();
+  if (cur.some((v) => v.videoId === item.videoId)) return; // idempotent
+  cur.unshift({ ...item, savedAt: Date.now() });
+  write(cur);
+}
+
+export function removeVideo(videoId: string) {
+  const cur = read().filter((v) => v.videoId !== videoId);
+  write(cur);
+}
+
+export function toggleSave(item: SavedItem): boolean {
+  const cur = read();
+  const idx = cur.findIndex((v) => v.videoId === item.videoId);
+  if (idx >= 0) {
+    cur.splice(idx, 1);
+    write(cur);
+    return false;
+  } else {
+    cur.unshift({ ...item, savedAt: Date.now() });
+    write(cur);
+    return true;
+  }
+}
+


### PR DESCRIPTION
## Summary
- add client-side library utility to normalize saved video entries
- wire grid save button to toggle library entries with immediate UI update
- ensure /saved page reads from centralized library

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: Cannot find package '@eslint/eslintrc')

------
https://chatgpt.com/codex/tasks/task_e_68c5c4628c2c8333bbb8a75b92933e85