### PR TITLE
feat: add prompt suggestions

### DIFF
--- a/src/app/api/suggest/route.ts
+++ b/src/app/api/suggest/route.ts
@@ -1,0 +1,83 @@
+import { NextRequest } from "next/server";
+
+export const runtime = "edge";
+
+type Body = {
+  input?: string;                 // current text in the prompt bar
+  savedTitles?: string[];         // top N saved video titles (client-provided)
+};
+
+export async function POST(req: NextRequest) {
+  try {
+    const { input = "", savedTitles = [] } = (await req.json()) as Body;
+
+    // Basic in-memory cache (edge process lifetime)
+    const key = JSON.stringify({ i: input.trim().toLowerCase(), s: savedTitles.slice(0, 12) });
+    // @ts-ignore
+    globalThis.__SUGGEST ||= new Map<string, { ts: number; val: string[] }>();
+    // @ts-ignore
+    const cache: Map<string, { ts: number; val: string[] }> = globalThis.__SUGGEST;
+    const now = Date.now();
+    const TTL = 10 * 60 * 1000; // 10m
+    const hit = cache.get(key);
+    if (hit && now - hit.ts < TTL) {
+      return Response.json({ suggestions: hit.val.slice(0, 6), cached: true });
+    }
+
+    const system = `You produce short, clickable prompt ideas for a video discovery app.
+Return ONLY JSON of the form: {"suggestions":["..."]}.
+Guidelines:
+- 4–8 words each, no punctuation at the end, no quotes.
+- Diverse but coherent; avoid duplicates.
+- If "input" is non-empty, bias suggestions to be natural next-steps for that input.
+- If "savedTitles" are provided, infer the user's tastes and include 2–3 that reflect them.
+- Keep them safe and generic; don't include offensive/NSFW content.`;
+
+    const user = JSON.stringify({ input, savedTitles: savedTitles.slice(0, 20) });
+
+    const model = process.env.INTENT_MODEL || "gpt-5-mini";
+    const apiKey = process.env.OPENAI_API_KEY;
+    if (!apiKey) return new Response("OPENAI_API_KEY missing", { status: 500 });
+
+    const r = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: `Bearer ${apiKey}` },
+      body: JSON.stringify({
+        model,
+        temperature: 0.7,
+        response_format: { type: "json_object" },
+        messages: [
+          { role: "system", content: system },
+          { role: "user", content: user }
+        ],
+      }),
+    });
+
+    if (!r.ok) return new Response(await r.text(), { status: r.status });
+
+    const data = await r.json();
+    let parsed: string[] = [];
+    try {
+      const obj = JSON.parse(data.choices?.[0]?.message?.content ?? "{}");
+      parsed = Array.isArray(obj.suggestions) ? obj.suggestions : [];
+    } catch {
+      parsed = [];
+    }
+    // Fallbacks if model returns nothing
+    if (parsed.length === 0) {
+      parsed = [
+        "deep dive interviews",
+        "quiet train rides",
+        "tech founders talks",
+        "cinematic nature scenes",
+        "history explainers",
+        "chill jazz concert"
+      ];
+    }
+
+    cache.set(key, { ts: now, val: parsed });
+    return Response.json({ suggestions: parsed.slice(0, 6) });
+  } catch (e: any) {
+    return new Response(`suggest error: ${e?.message || "unknown"}`, { status: 500 });
+  }
+}

--- a/src/components/PromptBar.tsx
+++ b/src/components/PromptBar.tsx
@@ -1,5 +1,6 @@
 "use client";
-import { useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { loadLibrary } from "@/lib/library";
 
 type Props = {
   onSubmit?: (text: string) => void;
@@ -10,44 +11,100 @@ type Props = {
 
 export default function PromptBar({ onSubmit, onRespin, initialValue = "", placeholder = "Type anything…" }: Props) {
   const [text, setText] = useState(initialValue);
+  const [suggestions, setSuggestions] = useState<string[]>([]);
+  const [loading, setLoading] = useState(false);
+  const abortRef = useRef<AbortController | null>(null);
 
-  function submit() {
+  // Build a short taste profile from Saved Library (titles only, capped)
+  const taste = useMemo(() => {
+    if (typeof window === "undefined") return [] as string[];
+    const saved = loadLibrary();
+    return saved.slice(0, 20).map(s => s.title).filter(Boolean);
+  }, []);
+
+  // Debounced fetch to /api/suggest whenever text changes (and on mount)
+  useEffect(() => {
     const q = text.trim();
-    if (!q) return;
-    if (onSubmit) return onSubmit(q);
-    // DEFAULT: let existing home behavior run (dispatch your /api/search)
-    // You likely already had this logic — keep it here:
-    window.dispatchEvent(new CustomEvent("bloom:search", { detail: { q } }));
+    setLoading(true);
+    abortRef.current?.abort();
+    const ctrl = new AbortController();
+    abortRef.current = ctrl;
+
+    const t = setTimeout(async () => {
+      try {
+        const r = await fetch("/api/suggest", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ input: q, savedTitles: taste }),
+          signal: ctrl.signal,
+        });
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        const { suggestions } = await r.json();
+        setSuggestions(Array.isArray(suggestions) ? suggestions : []);
+      } catch {
+        setSuggestions([]);
+      } finally {
+        setLoading(false);
+      }
+    }, 300);
+
+    return () => { clearTimeout(t); ctrl.abort(); };
+  }, [text, taste]);
+
+  function submit(val?: string) {
+    const value = (val ?? text).trim();
+    if (!value) return;
+    if (onSubmit) return onSubmit(value);
+    // Default: emit global events for home page handler (keep your existing behavior)
+    window.dispatchEvent(new CustomEvent("bloom:search", { detail: { q: value } }));
   }
 
   function respin() {
     if (onRespin) return onRespin();
-    // DEFAULT: home "Respin" behavior (emit event or call your handler)
     window.dispatchEvent(new CustomEvent("bloom:respin"));
   }
 
   return (
-    <div className="fixed inset-x-0 bottom-0 z-50 pb-[env(safe-area-inset-bottom)]">
-      <div className="mx-auto w-full max-w-[1400px] px-4 py-4 bg-white/80 backdrop-blur border-t">
-        <div className="flex gap-3">
-          <input
-            value={text}
-            onChange={(e) => setText(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") submit();
-            }}
-            placeholder={placeholder}
-            className="flex-1 rounded-xl border px-4 py-3 text-sm outline-none focus:ring-2 focus:ring-black/10"
-          />
-          <button
-            onClick={respin}
-            className="px-4 py-3 rounded-xl bg-orange-500 text-white text-sm font-medium"
-          >
-            Respin
-          </button>
+    <>
+      {/* suggestions stack just above the bar */}
+      <div className="fixed inset-x-0 bottom-[84px] z-40 pointer-events-none">
+        <div className="mx-auto w-full max-w-[1400px] px-4">
+          <div className="flex flex-wrap gap-2">
+            {suggestions.map((s, i) => (
+              <button
+                key={`${s}-${i}`}
+                onClick={(e) => { e.preventDefault(); setText(s); }}
+                className="pointer-events-auto px-3 py-1.5 rounded-full border text-sm bg-white hover:bg-slate-50"
+                title={s}
+              >
+                {s}
+              </button>
+            ))}
+            {loading && <div className="text-xs text-slate-400">thinking…</div>}
+          </div>
         </div>
       </div>
-    </div>
+
+      {/* bar */}
+      <div className="fixed inset-x-0 bottom-0 z-50 pb-[env(safe-area-inset-bottom)]">
+        <div className="mx-auto w-full max-w-[1400px] px-4 py-4 bg-white/80 backdrop-blur border-t">
+          <div className="flex gap-3">
+            <input
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+              onKeyDown={(e) => { if (e.key === "Enter") submit(); }}
+              placeholder={placeholder}
+              className="flex-1 rounded-xl border px-4 py-3 text-sm outline-none focus:ring-2 focus:ring-black/10"
+            />
+            <button onClick={() => submit()} className="px-4 py-3 rounded-xl bg-orange-500 text-white text-sm font-medium">
+              Bloom it
+            </button>
+            <button onClick={respin} className="px-4 py-3 rounded-xl bg-slate-900 text-white text-sm font-medium">
+              Respin
+            </button>
+          </div>
+        </div>
+      </div>
+    </>
   );
 }
-


### PR DESCRIPTION
## Summary
- add `/api/suggest` endpoint for LLM-based prompt ideas with caching and fallbacks
- enhance `PromptBar` with debounced suggestions, click-to-fill chips, and Bloom/Respin actions

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/openai)*

------
https://chatgpt.com/codex/tasks/task_e_68c5cb2755b88333a9937c4e09a78849