### PR TITLE
feat: add busy state to prompt bar

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -99,27 +99,35 @@ export default function Home() {
   }
 
   useEffect(() => {
-    function onSearch(e: any) {
-      if (loading) return;
-      const q: string = e.detail?.q ?? "";
-      const trimmed = q.trim().toLowerCase();
-      if (!trimmed) return;
-      if (trimmed === "saved") {
-        router.push("/saved");
-        return;
+    async function onSearch(e: any) {
+      try {
+        if (loading) return;
+        const q: string = e.detail?.q ?? "";
+        const trimmed = q.trim().toLowerCase();
+        if (!trimmed) return;
+        if (trimmed === "saved") {
+          router.push("/saved");
+          return;
+        }
+        await run(q, { respin: false });
+      } finally {
+        window.dispatchEvent(new Event("bloom:done"));
       }
-      run(q, { respin: false });
     }
-    function onRespin() {
-      if (loading) return;
-      if (!lastPromptRef.current) return;
-      run(lastPromptRef.current, { respin: true });
+    async function onRespin() {
+      try {
+        if (loading) return;
+        if (!lastPromptRef.current) return;
+        await run(lastPromptRef.current, { respin: true });
+      } finally {
+        window.dispatchEvent(new Event("bloom:done"));
+      }
     }
     window.addEventListener("bloom:search", onSearch as any);
-    window.addEventListener("bloom:respin", onRespin);
+    window.addEventListener("bloom:respin", onRespin as any);
     return () => {
       window.removeEventListener("bloom:search", onSearch as any);
-      window.removeEventListener("bloom:respin", onRespin);
+      window.removeEventListener("bloom:respin", onRespin as any);
     };
   }, [loading, router]);
 

--- a/src/app/saved/page.tsx
+++ b/src/app/saved/page.tsx
@@ -46,6 +46,7 @@ export default function SavedPage() {
   const respin = () => {
     const len = Math.max(items.length, 1);
     setOffset((o) => (o + 8) % len);
+    window.dispatchEvent(new Event("bloom:done"));
   };
 
   return (


### PR DESCRIPTION
## Summary
- show "Searching…" while prompt actions are running
- disable input and button until run completes or times out
- dispatch `bloom:done` events after search and saved page respin

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68c5d93dd5448333bec9a3ee7a514a30