### PR TITLE
fix: disable prerendering for home page due to useSearchParams

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,8 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { isSaved, toggleSave } from "@/lib/library";
 import PromptBar from "@/components/PromptBar";
 
+export const dynamic = "force-dynamic";
+
 interface Item {
   videoId: string;
   title: string;


### PR DESCRIPTION
## Summary
- force dynamic rendering on the home page to avoid build errors when using `useSearchParams`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/openai)*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5e9bb472883338dec2ae22abdafa9