### PR TITLE
fix: disable prerendering for saved page due to useSearchParams

### DIFF
--- a/src/app/saved/page.tsx
+++ b/src/app/saved/page.tsx
@@ -5,6 +5,8 @@ import { useRouter } from "next/navigation";
 import PromptBar from "@/components/PromptBar";
 import { loadLibrary, removeVideo, SavedItem } from "@/lib/library";
 
+export const dynamic = "force-dynamic";
+
 function buildDeckFromOffset(list: SavedItem[], offset: number, need = 8) {
   const out: SavedItem[] = [];
   if (!list.length) return out;


### PR DESCRIPTION
## Summary
- force dynamic rendering on `/saved` page to avoid pre-render build error when using `useSearchParams`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm run build` *(fails: next not found; dependencies missing)*


------
https://chatgpt.com/codex/tasks/task_e_68c5ec3b13e0833380b40c37c8147fdb