### PR TITLE
fix: force dynamic rendering for all pages using useSearchParams

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,12 +1,11 @@
 "use client";
 
+export const dynamic = "force-dynamic";
+
 import { useState, useRef, useEffect } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { isSaved, toggleSave } from "@/lib/library";
 import PromptBar from "@/components/PromptBar";
-
-export const dynamic = "force-dynamic";
-
 interface Item {
   videoId: string;
   title: string;

--- a/src/app/saved/page.tsx
+++ b/src/app/saved/page.tsx
@@ -1,12 +1,12 @@
 "use client";
+
+export const dynamic = "force-dynamic";
+
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import PromptBar from "@/components/PromptBar";
 import { loadLibrary, removeVideo, SavedItem } from "@/lib/library";
-
-export const dynamic = "force-dynamic";
-
 function buildDeckFromOffset(list: SavedItem[], offset: number, need = 8) {
   const out: SavedItem[] = [];
   if (!list.length) return out;


### PR DESCRIPTION
## Summary
- move `dynamic` export to the top of home page
- move `dynamic` export to the top of saved page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68c5ef29caf48333a7dc76a1d5dc58bf