### PR TITLE
fix(header): use Next Link to saved

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 export const dynamic = "force-dynamic";
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import Link from "next/link";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -30,12 +31,12 @@ export default function RootLayout({
       >
         <header className="p-4 text-xl font-semibold flex items-center justify-between">
           <a href="/" className="text-orange-500">Bloom</a>
-          <a
-            href="/later"
+          <Link
+            href="/saved"
             className="text-sm font-normal text-slate-600 hover:text-slate-900 underline underline-offset-4"
           >
             Watch Later
-          </a>
+          </Link>
         </header>
         {children}
       </body>


### PR DESCRIPTION
## Summary
- use Next.js Link for Watch Later header link
- point Watch Later link to `/saved`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc'; `npm install` returned 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c60f2a1c848333b326a53b1f85a474