### PR TITLE
style(ui): darken fonts to black and remove black top bar

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,7 +2,7 @@
 
 :root {
   --background: #ffffff;
-  --foreground: #171717;
+  --foreground: #000000;
 }
 
 @theme inline {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -29,7 +29,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <header className="p-4 text-xl font-semibold flex items-center justify-between">
+        <header className="p-4 text-xl font-semibold flex items-center justify-between bg-white">
           <a href="/" className="text-orange-500">Bloom</a>
           <Link
             href="/saved"


### PR DESCRIPTION
## Summary
- default text color is now solid black for better readability
- ensure header uses a white background to remove stray black bar

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68c6161814348333b4cc349bc723a4e6