### PR TITLE
style(readability): enforce black text defaults

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -24,3 +24,21 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+/* Readability overrides: make commonly used light text classes black */
+[class~="text-slate-500"],
+[class~="text-slate-600"],
+[class~="text-gray-500"],
+[class~="text-gray-600"],
+[class~="text-neutral-500"],
+[class~="text-neutral-600"],
+[class~="text-zinc-500"],
+[class~="text-zinc-600"] {
+  color: #000 !important;
+}
+
+/* If the project uses shadcn/ui tokens, this keeps “muted” text readable */
+:root {
+  --foreground: 0 0% 0%;
+  --muted-foreground: 0 0% 0%;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -27,7 +27,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased text-black`}
       >
         <header className="p-4 text-xl font-semibold flex items-center justify-between bg-white">
           <a href="/" className="text-orange-500">Bloom</a>


### PR DESCRIPTION
## Summary
- default page text to black
- force 500/600 Tailwind text utilities to render black for readability

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68c61a3207e88333993756bd3de916c0