### PR TITLE
feat(grid): render exactly 4 cards and hydrate 5–10 ranked YouTube comments per card (no other UI/UX changes)

### DIFF
--- a/src/lib/youtube/comments.ts
+++ b/src/lib/youtube/comments.ts
@@ -1,68 +1,137 @@
+import type { YTComment } from "./types";
+
 const YT_API = "https://www.googleapis.com/youtube/v3";
+const MAX_RESULTS_PER_VIDEO = 20;
+const MAX_ALLOWED = 10;
 
 function buildCommentsURL(videoId: string, key: string) {
   const u = new URL(`${YT_API}/commentThreads`);
   u.searchParams.set("part", "snippet");
   u.searchParams.set("videoId", videoId);
-  u.searchParams.set("maxResults", "2");
+  u.searchParams.set("maxResults", String(MAX_RESULTS_PER_VIDEO));
   u.searchParams.set("order", "relevance");
-  u.searchParams.set("textFormat", "plainText"); // returns plain text in textDisplay
+  u.searchParams.set("textFormat", "plainText");
   u.searchParams.set("key", key);
   return u.toString();
 }
 
-export async function fetchTopCommentsForId(videoId: string): Promise<import("./types").YTComment[]> {
-  const key = process.env.YOUTUBE_API_KEY;
-  if (!key) return [];
-  const url = buildCommentsURL(videoId, key);
-
-  // Cache on Vercel for 24h to protect quota
-  const r = await fetch(url, { next: { revalidate: 86400 } });
-  if (!r.ok) return [];
-
-  const json = await r.json();
-  const items = Array.isArray(json.items) ? json.items : [];
-
-  return items.map((it: any) => {
-    const s = it?.snippet?.topLevelComment?.snippet;
-    return {
-      id: it?.id ?? "",
-      author: s?.authorDisplayName ?? "Unknown",
-      text: (s?.textDisplay ?? "").toString(), // plain text due to textFormat=plainText
-      likes: typeof s?.likeCount === "number" ? s.likeCount : undefined,
-      publishedAt: s?.publishedAt ?? undefined,
-    };
-  });
+function normalizeText(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
 }
 
-// Batch wrapper with concurrency limit
+function hasVisibleCharacters(text: string): boolean {
+  const trimmed = text.trim();
+  if (!trimmed) return false;
+  return trimmed.replace(/\s+/g, "").length >= 8;
+}
+
+function computeRecencyBoost(publishedAt?: string): number {
+  if (!publishedAt) return 0;
+  const ts = Date.parse(publishedAt);
+  if (Number.isNaN(ts)) return 0;
+  const ageMs = Date.now() - ts;
+  if (ageMs <= 0) return 0.5;
+  const ageDays = ageMs / (1000 * 60 * 60 * 24);
+  const maxDays = 365;
+  const clampedRatio = Math.min(Math.max(ageDays / maxDays, 0), 1);
+  return 0.5 * (1 - clampedRatio);
+}
+
+export async function fetchTopCommentsForId(
+  videoId: string,
+  max = 8,
+): Promise<YTComment[]> {
+  const key = process.env.YOUTUBE_API_KEY;
+  if (!key) return [];
+  const limit = Math.min(MAX_ALLOWED, Math.max(1, Math.floor(max)));
+  const url = buildCommentsURL(videoId, key);
+
+  const response = await fetch(url, { next: { revalidate: 86400 } });
+  if (!response.ok) return [];
+
+  const json = await response.json();
+  const items: any[] = Array.isArray(json?.items) ? json.items : [];
+
+  const ranked = items
+    .map((item) => {
+      const snippet = item?.snippet?.topLevelComment?.snippet;
+      if (!snippet) return null;
+      const text = normalizeText((snippet?.textDisplay ?? "").toString());
+      if (!hasVisibleCharacters(text)) return null;
+      const likes =
+        typeof snippet?.likeCount === "number" && Number.isFinite(snippet.likeCount)
+          ? snippet.likeCount
+          : undefined;
+      const replies =
+        typeof item?.snippet?.totalReplyCount === "number" &&
+        Number.isFinite(item.snippet.totalReplyCount)
+          ? item.snippet.totalReplyCount
+          : undefined;
+      const publishedAt = typeof snippet?.publishedAt === "string" ? snippet.publishedAt : undefined;
+      const likeScore = likes ?? 0;
+      const replyScore = replies ? replies * 0.5 : 0;
+      const recencyBoost = computeRecencyBoost(publishedAt);
+      const score = likeScore + replyScore + recencyBoost;
+      const base: YTComment = {
+        id: (item?.id ?? "").toString(),
+        author: (snippet?.authorDisplayName ?? "Unknown").toString(),
+        text,
+      };
+      return {
+        ...base,
+        likes,
+        replies,
+        publishedAt,
+        score,
+      } satisfies YTComment;
+    })
+    .filter((c): c is YTComment => c != null)
+    .sort((a, b) => {
+      const scoreDiff = (b.score ?? 0) - (a.score ?? 0);
+      if (scoreDiff !== 0) return scoreDiff;
+      if (a.publishedAt && b.publishedAt) {
+        return Date.parse(b.publishedAt) - Date.parse(a.publishedAt);
+      }
+      return 0;
+    });
+
+  return ranked.slice(0, limit);
+}
+
+type BatchOptions = {
+  max?: number;
+  concurrency?: number;
+};
+
 export async function fetchTopCommentsBatch(
   ids: string[],
-  limit = 3,
-): Promise<Record<string, import("./types").YTComment[]>> {
-  const q: string[] = [...new Set(ids)]; // dedupe
-  const out: Record<string, import("./types").YTComment[]> = {};
-  let i = 0;
+  options: BatchOptions = {},
+): Promise<Record<string, YTComment[]>> {
+  const unique = Array.from(new Set(ids.filter((id) => id.trim().length > 0)));
+  const limit = Math.min(MAX_ALLOWED, Math.max(1, Math.floor(options.max ?? 8)));
+  const concurrency = Math.max(1, Math.floor(options.concurrency ?? 3));
+  const out: Record<string, YTComment[]> = {};
+  let cursor = 0;
 
   async function worker() {
-    while (i < q.length) {
-      const idx = i++;
-      const id = q[idx];
+    while (cursor < unique.length) {
+      const index = cursor++;
+      const id = unique[index];
       try {
-        // Per-video timeout ~1s to stay snappy
-        const res = await Promise.race([
-          fetchTopCommentsForId(id),
-          new Promise<import("./types").YTComment[]>((resolve) =>
-            setTimeout(() => resolve([]), 1000),
-          ),
+        const comments = await Promise.race<YTComment[]>([
+          fetchTopCommentsForId(id, limit),
+          new Promise<YTComment[]>((resolve) => setTimeout(() => resolve([]), 1000)),
         ]);
-        out[id] = res.slice(0, 2);
+        out[id] = comments;
       } catch {
         out[id] = [];
       }
     }
   }
 
-  await Promise.all(Array.from({ length: Math.min(limit, q.length) }, worker));
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, unique.length) }, () => worker()),
+  );
+
   return out;
 }

--- a/src/lib/youtube/types.ts
+++ b/src/lib/youtube/types.ts
@@ -3,5 +3,7 @@ export type YTComment = {
   author: string;
   text: string; // plain text, truncated client-side
   likes?: number;
+  replies?: number;
   publishedAt?: string; // ISO
+  score?: number;
 };


### PR DESCRIPTION
## Summary
- cap the primary grid at four cards and lazy-load YouTube comments for those items
- add an API endpoint that batches per-video comment lookups, ranks them, and honours the ENABLE_YT_COMMENTS flag
- enhance the YouTube comment utilities with scoring, filtering, caching, and concurrency-aware batching helpers

## Testing
- npm run lint *(fails: missing optional dependency @eslint/eslintrc in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8432e48f48333837d7d866de2c3b4