### PR TITLE
Fix Shipyard CI to be repo-aware and publish commit status

### DIFF
--- a/.github/workflows/shipyard.yml
+++ b/.github/workflows/shipyard.yml
@@ -1,0 +1,106 @@
+name: Shipyard CI
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: shipyard-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      statuses: write  # needed to create commit statuses for the Bridge
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Enable corepack + pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@9 --activate
+          pnpm -v
+
+      - name: Install dependencies
+        run: |
+          if [ -f pnpm-lock.yaml ]; then
+            pnpm install --frozen-lockfile
+          else
+            pnpm install
+          fi
+
+      - name: Typecheck (if script exists)
+        run: |
+          if node -e "process.exit(!((require('./package.json').scripts||{}).typecheck))"; then
+            echo "Running pnpm typecheck"
+            pnpm typecheck
+          else
+            echo "No typecheck script; skipping"
+          fi
+
+      - name: Lint (if script exists)
+        run: |
+          if node -e "process.exit(!((require('./package.json').scripts||{}).lint))"; then
+            echo "Running pnpm lint"
+            pnpm lint
+          else
+            echo "No lint script; skipping"
+          fi
+
+      - name: Test (if script exists)
+        run: |
+          if node -e "process.exit(!((require('./package.json').scripts||{}).test))"; then
+            echo "Running pnpm test"
+            pnpm test -- --reporter=dot
+          else
+            echo "No test script; skipping"
+          fi
+
+      - name: Build (if script exists)
+        run: |
+          if node -e "process.exit(!((require('./package.json').scripts||{}).build))"; then
+            echo "Running pnpm build"
+            pnpm build
+          else
+            echo "No build script; skipping"
+          fi
+
+      - name: Publish commit status (success)
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const sha = context.payload.pull_request ? context.payload.pull_request.head.sha : context.sha;
+            await github.request('POST /repos/{owner}/{repo}/statuses/{sha}', {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha,
+              state: 'success',
+              context: 'shipyard/ci',
+              description: 'Shipyard CI passed',
+              target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+            });
+
+      - name: Publish commit status (failure)
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const sha = context.payload.pull_request ? context.payload.pull_request.head.sha : context.sha;
+            await github.request('POST /repos/{owner}/{repo}/statuses/{sha}', {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha,
+              state: 'failure',
+              context: 'shipyard/ci',
+              description: 'Shipyard CI failed',
+              target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+            });


### PR DESCRIPTION
## Summary
- replace the Shipyard CI workflow to install pnpm via corepack and cache dependencies
- run typecheck, lint, test, and build scripts conditionally based on package.json definitions
- publish shipyard/ci commit statuses for success and failure cases

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68c85a8526f88333bcf8cc0f9bd9f33a