### PR TITLE
Fix Shipyard CI to install pnpm

### DIFF
--- a/.github/workflows/shipyard.yml
+++ b/.github/workflows/shipyard.yml
@@ -1,0 +1,92 @@
+name: Shipyard CI
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: shipyard-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      statuses: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Setup pnpm 9
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Versions
+        run: |
+          node -v
+          pnpm -v
+
+      - name: Install dependencies
+        run: |
+          if [ -f pnpm-lock.yaml ]; then
+            pnpm install --frozen-lockfile
+          else
+            pnpm install
+          fi
+
+      - name: Typecheck (if script exists)
+        run: |
+          node -e "process.exit(!((require('./package.json').scripts||{}).typecheck))" || { echo 'skip'; exit 0; }
+          pnpm typecheck
+
+      - name: Lint (if script exists)
+        run: |
+          node -e "process.exit(!((require('./package.json').scripts||{}).lint))" || { echo 'skip'; exit 0; }
+          pnpm lint
+
+      - name: Test (if script exists)
+        run: |
+          node -e "process.exit(!((require('./package.json').scripts||{}).test))" || { echo 'skip'; exit 0; }
+          pnpm test -- --reporter=dot
+
+      - name: Build (if script exists)
+        run: |
+          node -e "process.exit(!((require('./package.json').scripts||{}).build))" || { echo 'skip'; exit 0; }
+          pnpm build
+
+      - name: shipyard/ci (success)
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const sha = context.payload.pull_request ? context.payload.pull_request.head.sha : context.sha;
+            await github.request('POST /repos/{owner}/{repo}/statuses/{sha}', {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha,
+              state: 'success',
+              context: 'shipyard/ci',
+              description: 'Shipyard CI passed',
+              target_url: `https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}`
+            });
+
+      - name: shipyard/ci (failure)
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const sha = context.payload.pull_request ? context.payload.pull_request.head.sha : context.sha;
+            await github.request('POST /repos/{owner}/{repo}/statuses/{sha}', {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha,
+              state: 'failure',
+              context: 'shipyard/ci',
+              description: 'Shipyard CI failed',
+              target_url: `https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}`
+            });


### PR DESCRIPTION
## Summary
- add Shipyard CI workflow that installs pnpm 9 before running scripts
- run typecheck, lint, test, and build only if the corresponding npm scripts exist
- post a single shipyard/ci status on success or failure

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68c86cb54ad48333bb40a80f2045f592