### PR TITLE
feat(reddit): add bottom “Reddit strip” with 3–4 related posts via PSE (flag-gated)

### DIFF
--- a/src/app/api/reddit/related/route.ts
+++ b/src/app/api/reddit/related/route.ts
@@ -1,0 +1,131 @@
+import { NextResponse } from "next/server";
+import { redditPseSearch, type RedditPseResult } from "@/lib/reddit/pse";
+
+export const runtime = "edge";
+
+interface RedditLink {
+  title: string;
+  url: string;
+  subreddit?: string;
+  image?: string | null;
+}
+
+interface Body {
+  topics?: unknown;
+  limit?: unknown;
+}
+
+const CACHE_CONTROL = "s-maxage=120, stale-while-revalidate=300";
+
+function normalizeTitle(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(/[\[\](){}]/g, "")
+    .replace(/\p{Extended_Pictographic}/gu, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function extractSubreddit(url: string, displayLink?: string): string | undefined {
+  try {
+    const parsed = new URL(url);
+    const parts = parsed.pathname.split("/").filter(Boolean);
+    const rIndex = parts.findIndex((p) => p.toLowerCase() === "r");
+    if (rIndex !== -1 && parts.length > rIndex + 1) {
+      return `r/${parts[rIndex + 1]}`;
+    }
+  } catch {}
+  if (displayLink && /reddit\.com\/r\//i.test(displayLink)) {
+    const match = displayLink.match(/r\/[^/]+/i);
+    if (match) return match[0];
+  }
+  return undefined;
+}
+
+function tokenizeTopics(topics: string[]): string[] {
+  const tokens = new Set<string>();
+  for (const topic of topics) {
+    for (const word of topic.split(/[^A-Za-z0-9+]+/)) {
+      const trimmed = word.trim().toLowerCase();
+      if (trimmed.length <= 2) continue;
+      tokens.add(trimmed);
+    }
+  }
+  return Array.from(tokens);
+}
+
+function scoreResult(result: RedditPseResult, topicTokens: string[]): number {
+  let score = 0;
+  const title = result.title.toLowerCase();
+  for (const token of topicTokens) {
+    if (token && title.includes(token)) {
+      score += 2;
+    }
+  }
+  const subreddit = extractSubreddit(result.url, result.displayLink);
+  if (subreddit) {
+    score += 1.5;
+  }
+  return score;
+}
+
+export async function POST(req: Request) {
+  const body = (await req.json().catch(() => ({}))) as Body;
+  const topics = Array.isArray(body?.topics)
+    ? body.topics.filter((t): t is string => typeof t === "string" && t.trim().length > 0)
+    : [];
+
+  const limitRaw = typeof body?.limit === "number" ? body.limit : undefined;
+  const limit = Math.min(Math.max(limitRaw ?? 4, 1), 4);
+
+  if (!topics.length) {
+    return NextResponse.json<RedditLink[]>([], {
+      headers: { "cache-control": CACHE_CONTROL },
+    });
+  }
+
+  const selectedTopics = topics.slice(0, 2);
+  const quoted = selectedTopics
+    .map((topic) => topic.trim())
+    .filter(Boolean)
+    .map((topic) => (topic.includes(" ") ? `"${topic}"` : topic));
+  const queryTopic = quoted.join(" OR ");
+  const query = queryTopic ? `${queryTopic}` : selectedTopics[0];
+
+  const results = await redditPseSearch(query, 6);
+  if (!results.length) {
+    return NextResponse.json<RedditLink[]>([], {
+      headers: { "cache-control": CACHE_CONTROL },
+    });
+  }
+
+  const topicTokens = tokenizeTopics(selectedTopics);
+  const seen = new Set<string>();
+  const ranked: { item: RedditPseResult; score: number }[] = [];
+
+  for (const item of results) {
+    const normTitle = normalizeTitle(item.title);
+    if (!normTitle || seen.has(normTitle)) continue;
+    seen.add(normTitle);
+    const score = scoreResult(item, topicTokens);
+    ranked.push({ item, score });
+  }
+
+  ranked.sort((a, b) => b.score - a.score);
+
+  const payload: RedditLink[] = [];
+  for (const { item } of ranked) {
+    const subreddit = extractSubreddit(item.url, item.displayLink);
+    payload.push({
+      title: item.title,
+      url: item.url,
+      subreddit: subreddit,
+      image: item.image ?? null,
+    });
+    if (payload.length >= limit) break;
+  }
+
+  return NextResponse.json(payload, {
+    headers: { "cache-control": CACHE_CONTROL },
+  });
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,12 +2,13 @@
 
 export const dynamic = "force-dynamic";
 
-import { useState, useRef, useEffect, Suspense, useCallback } from "react";
+import { useState, useRef, useEffect, Suspense, useCallback, useMemo } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { isSaved, toggleSave } from "@/lib/library";
 import PromptBar from "@/components/PromptBar";
 import type { YTComment } from "@/lib/youtube/types";
 import { extractYouTubeId } from "@/lib/youtube/utils";
+import RedditStrip from "@/components/RedditStrip";
 interface Item {
   videoId: string;
   title: string;
@@ -22,6 +23,135 @@ const FEED_MODE = process.env.NEXT_PUBLIC_FEED_MODE === "1";
 const RESULTS_LIMIT = FEED_MODE ? 8 : 4;
 const ENABLE_YT_COMMENTS =
   process.env.NEXT_PUBLIC_ENABLE_YT_COMMENTS !== "0";
+const ENABLE_REDDIT_STRIP =
+  process.env.NEXT_PUBLIC_ENABLE_REDDIT_STRIP === "1" ||
+  process.env.ENABLE_REDDIT_STRIP === "1";
+
+const STOPWORDS = new Set([
+  "the",
+  "and",
+  "for",
+  "with",
+  "from",
+  "that",
+  "this",
+  "have",
+  "has",
+  "will",
+  "says",
+  "after",
+  "over",
+  "into",
+  "about",
+  "your",
+  "their",
+  "them",
+  "they",
+  "you",
+  "our",
+  "are",
+  "was",
+  "were",
+  "been",
+  "being",
+  "just",
+  "more",
+  "less",
+  "than",
+  "its",
+  "it's",
+  "new",
+  "news",
+  "live",
+  "update",
+  "updates",
+  "breaking",
+  "latest",
+  "watch",
+  "today",
+  "tonight",
+  "video",
+]);
+
+function isSignificantWord(word: string): boolean {
+  if (!word) return false;
+  const cleaned = word.replace(/^["'`]+|["'`]+$/g, "");
+  if (cleaned.length < 3) return false;
+  const lower = cleaned.toLowerCase();
+  if (STOPWORDS.has(lower)) return false;
+  const first = cleaned[0];
+  const isLetter = /[A-Za-z]/.test(first);
+  if (!isLetter) return false;
+  const isAllCaps = cleaned === cleaned.toUpperCase();
+  const startsUpper = first === first.toUpperCase();
+  return startsUpper || isAllCaps;
+}
+
+function deriveTopics(items: Item[]): string[] {
+  const singles = new Map<string, { label: string; count: number }>();
+  const bigrams = new Map<string, { label: string; count: number }>();
+
+  for (const item of items.slice(0, RESULTS_LIMIT)) {
+    const candidates = [item.title, item.channelTitle].filter(
+      (v): v is string => typeof v === "string" && v.length > 0,
+    );
+    for (const text of candidates) {
+      const words = text.match(/[A-Za-z][A-Za-z0-9'&-]*/g);
+      if (!words) continue;
+      for (let i = 0; i < words.length; i++) {
+        const word = words[i];
+        if (isSignificantWord(word)) {
+          const key = word.toLowerCase();
+          const prev = singles.get(key);
+          if (prev) {
+            prev.count += 1;
+          } else {
+            singles.set(key, { label: word, count: 1 });
+          }
+        }
+        if (i < words.length - 1) {
+          const next = words[i + 1];
+          if (isSignificantWord(word) && isSignificantWord(next)) {
+            const phrase = `${word} ${next}`;
+            const key = phrase.toLowerCase();
+            const prev = bigrams.get(key);
+            if (prev) {
+              prev.count += 1;
+            } else {
+              bigrams.set(key, { label: phrase, count: 1 });
+            }
+          }
+        }
+      }
+    }
+  }
+
+  const scored: { label: string; score: number; type: "single" | "bigram" }[] = [];
+  for (const value of bigrams.values()) {
+    scored.push({ label: value.label, score: value.count * 2 + 0.5, type: "bigram" });
+  }
+  for (const value of singles.values()) {
+    scored.push({ label: value.label, score: value.count, type: "single" });
+  }
+
+  scored.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    if (a.type !== b.type) return a.type === "bigram" ? -1 : 1;
+    return a.label.localeCompare(b.label);
+  });
+
+  const result: string[] = [];
+  const seen = new Set<string>();
+  for (const entry of scored) {
+    const normalized = entry.label.toLowerCase();
+    if (seen.has(normalized)) continue;
+    seen.add(normalized);
+    result.push(entry.label);
+    if (result.length >= 3) break;
+  }
+
+  return result;
+}
 
 function Spinner() {
   return (
@@ -57,6 +187,16 @@ export default function Home() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const initialQ = FEED_MODE ? "" : searchParams.get("q") ?? "";
+
+  const redditTopics = useMemo(() => {
+    if (!ENABLE_REDDIT_STRIP) return [];
+    if (!items.length) return [];
+    const derived = deriveTopics(items);
+    if (derived.length === 0) {
+      return ["breaking news"];
+    }
+    return derived.slice(0, 3);
+  }, [items]);
 
   const runSearch = useCallback(
     async (q: string, { respin }: { respin: boolean }) => {
@@ -226,84 +366,87 @@ export default function Home() {
     <Suspense fallback={null}>
       <>
         <main className="min-h-[100svh] bg-white">
-        <div className="mx-auto w-full max-w-[1400px] px-4 pt-4 pb-[88px]">
-          {degraded && (
-            <div className="mb-4 rounded border border-yellow-200 bg-yellow-100 p-2 text-center text-sm text-yellow-800">
-              We’re running in low‑quota mode. Playing and saving still work; some
-              stats are hidden.
+          <div className="mx-auto w-full max-w-[1400px] px-4 pt-4 pb-[88px]">
+            {degraded && (
+              <div className="mb-4 rounded border border-yellow-200 bg-yellow-100 p-2 text-center text-sm text-yellow-800">
+                We’re running in low‑quota mode. Playing and saving still work; some
+                stats are hidden.
+              </div>
+            )}
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+              {items.slice(0, RESULTS_LIMIT).map((it) => {
+                const savedNow = isSaved(it.videoId);
+                const ytId = extractYouTubeId(it.youtubeUrl);
+                const comments = ytId ? ytComments[ytId] : undefined;
+                return (
+                  <a
+                    key={it.videoId}
+                    href={it.youtubeUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="relative rounded-2xl shadow-sm border border-slate-200 overflow-hidden hover:shadow-md transition"
+                  >
+                    <div className="aspect-video overflow-hidden relative">
+                      <img
+                        src={it.thumbnailUrl}
+                        alt={it.title}
+                        className="w-full h-full object-cover"
+                      />
+                      <button
+                        type="button"
+                        onClick={(e) => {
+                          e.preventDefault();
+                          toggleSave({
+                            videoId: it.videoId,
+                            title: it.title,
+                            channelTitle: it.channelTitle,
+                            youtubeUrl: it.youtubeUrl,
+                            thumbnailUrl: it.thumbnailUrl,
+                          });
+                          // Force a re-render so isSaved() reflects immediately
+                          setItems((cur) => [...cur]);
+                        }}
+                        aria-label={savedNow ? "Saved" : "Save to Watch Later"}
+                        className={`absolute right-2 top-2 rounded-full px-2.5 py-1.5 text-xs font-semibold shadow ${
+                          savedNow
+                            ? "bg-slate-700 text-white"
+                            : "bg-orange-500 text-white hover:bg-orange-600"
+                        }`}
+                      >
+                        {savedNow ? "✓ Saved" : "Save"}
+                      </button>
+                    </div>
+                    <div className="p-3">
+                      <div className="text-sm font-medium leading-snug line-clamp-2">
+                        {it.title}
+                      </div>
+                      <div className="mt-1 text-xs text-black/80">
+                        {it.channelTitle}
+                      </div>
+                      {ENABLE_YT_COMMENTS && ytId && comments && comments.length > 0
+                        ? (
+                            <div className="mt-2 space-y-1">
+                              {comments.slice(0, 3).map((c) => (
+                                <div
+                                  key={c.id}
+                                  className="text-sm text-black/80 leading-snug line-clamp-2"
+                                >
+                                  <span className="italic">“{c.text}”</span>{" "}
+                                  <span className="text-black/60">— {c.author}</span>
+                                </div>
+                              ))}
+                            </div>
+                          )
+                        : null}
+                    </div>
+                  </a>
+                );
+              })}
             </div>
-          )}
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-            {items.slice(0, RESULTS_LIMIT).map((it) => {
-              const savedNow = isSaved(it.videoId);
-              const ytId = extractYouTubeId(it.youtubeUrl);
-              const comments = ytId ? ytComments[ytId] : undefined;
-              return (
-                <a
-                  key={it.videoId}
-                  href={it.youtubeUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="relative rounded-2xl shadow-sm border border-slate-200 overflow-hidden hover:shadow-md transition"
-                >
-                  <div className="aspect-video overflow-hidden relative">
-                    <img
-                      src={it.thumbnailUrl}
-                      alt={it.title}
-                      className="w-full h-full object-cover"
-                    />
-                    <button
-                      type="button"
-                      onClick={(e) => {
-                        e.preventDefault();
-                        toggleSave({
-                          videoId: it.videoId,
-                          title: it.title,
-                          channelTitle: it.channelTitle,
-                          youtubeUrl: it.youtubeUrl,
-                          thumbnailUrl: it.thumbnailUrl,
-                        });
-                        // Force a re-render so isSaved() reflects immediately
-                        setItems((cur) => [...cur]);
-                      }}
-                      aria-label={savedNow ? "Saved" : "Save to Watch Later"}
-                      className={`absolute right-2 top-2 rounded-full px-2.5 py-1.5 text-xs font-semibold shadow ${
-                        savedNow
-                          ? "bg-slate-700 text-white"
-                          : "bg-orange-500 text-white hover:bg-orange-600"
-                      }`}
-                    >
-                      {savedNow ? "✓ Saved" : "Save"}
-                    </button>
-                  </div>
-                  <div className="p-3">
-                    <div className="text-sm font-medium leading-snug line-clamp-2">
-                      {it.title}
-                    </div>
-                    <div className="mt-1 text-xs text-black/80">
-                      {it.channelTitle}
-                    </div>
-                    {ENABLE_YT_COMMENTS && ytId && comments && comments.length > 0
-                      ? (
-                          <div className="mt-2 space-y-1">
-                            {comments.slice(0, 3).map((c) => (
-                              <div
-                                key={c.id}
-                                className="text-sm text-black/80 leading-snug line-clamp-2"
-                              >
-                                <span className="italic">“{c.text}”</span>{" "}
-                                <span className="text-black/60">— {c.author}</span>
-                              </div>
-                            ))}
-                          </div>
-                        )
-                      : null}
-                  </div>
-                </a>
-              );
-            })}
+            {ENABLE_REDDIT_STRIP && redditTopics.length > 0 ? (
+              <RedditStrip topics={redditTopics} />
+            ) : null}
           </div>
-        </div>
         </main>
         {!FEED_MODE ? (
           <PromptBar initialValue={initialQ} initialSubmitted={initialQ} />

--- a/src/components/RedditStrip.tsx
+++ b/src/components/RedditStrip.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+type RedditLink = {
+  title: string;
+  url: string;
+  subreddit?: string;
+  image?: string | null;
+};
+
+interface Props {
+  topics: string[];
+}
+
+export default function RedditStrip({ topics }: Props) {
+  const [links, setLinks] = useState<RedditLink[] | null>(null);
+
+  const payload = useMemo(() => {
+    const cleaned = Array.isArray(topics)
+      ? topics
+          .map((t) => t.trim())
+          .filter((t, idx, arr) => t.length > 0 && arr.indexOf(t) === idx)
+      : [];
+    return cleaned.slice(0, 4);
+  }, [topics]);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      if (!payload.length) {
+        setLinks([]);
+        return;
+      }
+      try {
+        const res = await fetch("/api/reddit/related", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ topics: payload, limit: 4 }),
+        });
+        if (!res.ok) return;
+        const data = await res.json();
+        if (!cancelled && Array.isArray(data)) {
+          setLinks(data as RedditLink[]);
+        }
+      } catch {
+        if (!cancelled) setLinks([]);
+      }
+    }
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [payload]);
+
+  if (!payload.length || !links || links.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="mt-6">
+      <div className="mb-2 text-xs uppercase tracking-wide text-black/50">
+        Related on Reddit
+      </div>
+      <div className="flex flex-wrap gap-3">
+        {links.slice(0, 4).map((link) => (
+          <a
+            key={link.url}
+            href={link.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex min-w-0 items-start gap-2 rounded-lg border border-black/10 bg-white p-2 shadow-sm transition hover:border-black/20 hover:shadow"
+          >
+            {link.image ? (
+              <img
+                src={link.image}
+                alt=""
+                className="h-10 w-10 flex-shrink-0 rounded object-cover"
+              />
+            ) : null}
+            <div className="min-w-0">
+              <div className="truncate text-sm font-medium text-black">
+                {link.title}
+              </div>
+              {link.subreddit ? (
+                <div className="text-xs text-black/60">{link.subreddit}</div>
+              ) : null}
+            </div>
+          </a>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/reddit/pse.ts
+++ b/src/lib/reddit/pse.ts
@@ -1,0 +1,115 @@
+interface RedditSearchItem {
+  title?: string;
+  link?: string;
+  displayLink?: string;
+  pagemap?: any;
+}
+
+function normalizeUrl(url: string): string | null {
+  try {
+    const u = new URL(url);
+    if (!u.hostname.includes("reddit.com")) return null;
+    return u.toString();
+  } catch {
+    return null;
+  }
+}
+
+async function safeFetch(url: string, init?: RequestInit): Promise<Response | null> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10_000);
+  try {
+    const res = await fetch(url, { ...init, signal: controller.signal });
+    if (!res.ok) {
+      try {
+        const text = await res.text();
+        console.error("Reddit PSE API error:", res.status, text);
+      } catch {
+        console.error("Reddit PSE API error:", res.status, "(no body)");
+      }
+      return null;
+    }
+    return res;
+  } catch (err) {
+    console.error("Reddit PSE API network error:", (err as Error)?.message || err);
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export interface RedditPseResult {
+  title: string;
+  url: string;
+  displayLink?: string;
+  image?: string | null;
+}
+
+export async function redditPseSearch(
+  query: string,
+  limit = 6,
+): Promise<RedditPseResult[]> {
+  const key = process.env.PSE_API_KEY;
+  const cx = process.env.PSE_CX;
+  if (!key || !cx) return [];
+
+  const trimmed = query.trim();
+  if (!trimmed) return [];
+
+  const baseQuery = `${trimmed} site:reddit.com -site:reddit.com/r/AskReddit`;
+
+  const url = new URL("https://www.googleapis.com/customsearch/v1");
+  url.search = new URLSearchParams({
+    key,
+    cx,
+    q: baseQuery,
+    num: String(Math.min(limit, 10)),
+    dateRestrict: "d2",
+  }).toString();
+
+  const res = await safeFetch(url.toString());
+  if (!res) return [];
+
+  let data: any;
+  try {
+    data = await res.json();
+  } catch {
+    return [];
+  }
+
+  const items: RedditPseResult[] = [];
+  if (Array.isArray(data?.items)) {
+    for (const item of data.items as RedditSearchItem[]) {
+      const link = typeof item.link === "string" ? normalizeUrl(item.link) : null;
+      const title = typeof item.title === "string" ? item.title.trim() : "";
+      if (!link || !title) continue;
+
+      let image: string | null = null;
+      const pagemap = item.pagemap || {};
+      const meta = Array.isArray(pagemap?.metatags) ? pagemap.metatags[0] : null;
+      if (meta && typeof meta === "object") {
+        const candidate = meta["og:image"];
+        if (typeof candidate === "string" && candidate) {
+          image = candidate;
+        }
+      }
+      if (!image && Array.isArray(pagemap?.cse_thumbnail)) {
+        const thumb = pagemap.cse_thumbnail[0]?.src;
+        if (typeof thumb === "string" && thumb) {
+          image = thumb;
+        }
+      }
+
+      items.push({
+        title,
+        url: link,
+        displayLink: typeof item.displayLink === "string" ? item.displayLink : undefined,
+        image,
+      });
+
+      if (items.length >= limit) break;
+    }
+  }
+
+  return items;
+}


### PR DESCRIPTION
## Summary
- add a Google PSE helper dedicated to fetching Reddit links
- expose a `/api/reddit/related` endpoint that ranks and caches Reddit link candidates
- derive feed topics on the homepage and render a flag-gated Reddit strip component below the grid

## Testing
- npm run lint *(fails: repository cannot download @eslint/eslintrc from npm registry in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cabdcc9b448333a578142f414647a3