### PR TITLE
Switch brand orange accents to red

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -30,7 +30,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased text-black`}
       >
         <header className="p-4 text-xl font-semibold flex items-center justify-between bg-white">
-          <a href="/" className="text-orange-500">Bloom</a>
+          <a href="/" className="text-red-500">Bloom</a>
           <Link
             href="/saved"
             className="text-sm font-normal text-slate-600 hover:text-slate-900 underline underline-offset-4"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -410,7 +410,7 @@ export default function Home() {
                         className={`absolute right-2 top-2 rounded-full px-2.5 py-1.5 text-xs font-semibold shadow ${
                           savedNow
                             ? "bg-slate-700 text-white"
-                            : "bg-orange-500 text-white hover:bg-orange-600"
+                            : "bg-red-500 text-white hover:bg-red-600"
                         }`}
                       >
                         {savedNow ? "✓ Saved" : "Save"}

--- a/src/components/PromptBar.tsx
+++ b/src/components/PromptBar.tsx
@@ -161,7 +161,7 @@ export default function PromptBar({
               onClick={doAction}
               disabled={busy}
               aria-busy={busy ? "true" : "false"}
-              className="px-4 py-3 rounded-xl bg-orange-500 text-white text-sm font-medium disabled:opacity-60"
+              className="px-4 py-3 rounded-xl bg-red-500 text-white text-sm font-medium disabled:opacity-60"
             >
               {buttonLabel}
             </button>


### PR DESCRIPTION
## Summary
- update the Bloom header link to use the red-500 Tailwind color
- shift action buttons from orange-500/600 Tailwind shades to their red counterparts to maintain intensity

## Testing
- npm run lint *(fails: missing @eslint/eslintrc package; npm install blocked by 403 from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68cb034f9a7c83339fbdc2cb66b88c3a