### PR TITLE
Swap brand accents from red to blue

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -30,7 +30,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased text-black`}
       >
         <header className="p-4 text-xl font-semibold flex items-center justify-between bg-white">
-          <a href="/" className="text-red-500">Bloom</a>
+          <a href="/" className="text-blue-500">Bloom</a>
           <Link
             href="/saved"
             className="text-sm font-normal text-slate-600 hover:text-slate-900 underline underline-offset-4"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -410,7 +410,7 @@ export default function Home() {
                         className={`absolute right-2 top-2 rounded-full px-2.5 py-1.5 text-xs font-semibold shadow ${
                           savedNow
                             ? "bg-slate-700 text-white"
-                            : "bg-red-500 text-white hover:bg-red-600"
+                            : "bg-blue-500 text-white hover:bg-blue-600"
                         }`}
                       >
                         {savedNow ? "✓ Saved" : "Save"}

--- a/src/components/PromptBar.tsx
+++ b/src/components/PromptBar.tsx
@@ -161,7 +161,7 @@ export default function PromptBar({
               onClick={doAction}
               disabled={busy}
               aria-busy={busy ? "true" : "false"}
-              className="px-4 py-3 rounded-xl bg-red-500 text-white text-sm font-medium disabled:opacity-60"
+              className="px-4 py-3 rounded-xl bg-blue-500 text-white text-sm font-medium disabled:opacity-60"
             >
               {buttonLabel}
             </button>


### PR DESCRIPTION
## Summary
- retarget Bloom header link to use blue brand color
- update prompt action button and save CTA to blue Tailwind variants

## Testing
- npm run lint *(fails: missing @eslint/eslintrc due to install blocked by 403 fetching openai)*

------
https://chatgpt.com/codex/tasks/task_e_68cb0bd5bb448333b052cb8b4b2c45a3