### PR TITLE
Update header label to Bloom — LIVE

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -30,7 +30,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased text-black`}
       >
         <header className="p-4 text-xl font-semibold flex items-center justify-between bg-white">
-          <a href="/" className="text-red-500">Bloom</a>
+          <a href="/" className="text-red-500">Bloom — LIVE</a>
           <Link
             href="/saved"
             className="text-sm font-normal text-slate-600 hover:text-slate-900 underline underline-offset-4"


### PR DESCRIPTION
## Summary
- update the header anchor text to display “Bloom — LIVE”

## Testing
- npm run lint *(fails: missing @eslint/eslintrc dependency because npm install cannot reach registry)*

------
https://chatgpt.com/codex/tasks/task_e_68cb2df4b38c8333b1de8de4b4a3673e