### PR TITLE
Switch header brand color to pink

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -30,7 +30,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased text-black`}
       >
         <header className="p-4 text-xl font-semibold flex items-center justify-between bg-white">
-          <a href="/" className="text-purple-500">Bloom — LIVE</a>
+          <a href="/" className="text-pink-500">Bloom — LIVE</a>
           <Link
             href="/saved"
             className="text-sm font-normal text-slate-600 hover:text-slate-900 underline underline-offset-4"


### PR DESCRIPTION
## Summary
- update the header brand link color to use Tailwind's pink palette as requested

## Testing
- not run (style-only change)

## Before / After
```diff
-          <a href="/" className="text-purple-500">Bloom — LIVE</a>
+          <a href="/" className="text-pink-500">Bloom — LIVE</a>
```


------
https://chatgpt.com/codex/tasks/task_e_68cc00dd307c8333b76730a67c7d0257