### PR TITLE
Change header brand color to red

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -30,7 +30,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased text-black`}
       >
         <header className="p-4 text-xl font-semibold flex items-center justify-between bg-white">
-          <a href="/" className="text-green-500">Bloom — LIVE</a>
+          <a href="/" className="text-red-500">Bloom — LIVE</a>
           <Link
             href="/saved"
             className="text-sm font-normal text-slate-600 hover:text-slate-900 underline underline-offset-4"


### PR DESCRIPTION
## Summary
- update the header brand link class to use the red Tailwind color

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cca3bf59b483338256ac8f0198f554