### PR TITLE
Add workflow to auto-merge labeled PRs

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,30 @@
+name: Auto-merge Codex PRs
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled]
+  workflow_run:
+    workflows: ['Shipyard CI']
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  merge:
+    if: >
+      (github.event_name == 'pull_request' &&
+       contains(join(github.event.pull_request.labels.*.name, ','), 'automerge'))
+      || (github.event_name == 'workflow_run' &&
+          github.event.workflow_run.conclusion == 'success' &&
+          github.event.workflow_run.event == 'pull_request')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: peter-evans/auto-merge@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          merge-method: squash
+          commit-message: pull-request-title
+          required-labels: automerge
+          pull-request: ${{ github.event.pull_request.url || github.event.workflow_run.pull_requests[0].url }}

--- a/README.md
+++ b/README.md
@@ -48,3 +48,7 @@ NEXT_PUBLIC_ENABLE_YT_COMMENTS=1
 Shipyard Bridge e2e test ✅
 
 Shipyard Bridge validation test #2 ✅
+
+## Auto-merge PRs
+
+Add the `automerge` label to a pull request to enable the auto-merge workflow. Once the required checks, including Shipyard CI, finish successfully, the PR will be merged automatically using a squash commit titled with the pull request name.


### PR DESCRIPTION
## Summary
- add an auto-merge workflow that squashes PRs labeled `automerge` once Shipyard CI succeeds
- document how to opt into auto-merge in the README

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68ccab503c888333ad06d09819a06137