### PR TITLE
Enable auto-merge for labeled PRs

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,24 +1,19 @@
-name: Auto-merge Codex PRs
-
+name: Auto-merge labeled PRs
 on:
   pull_request:
     types: [opened, reopened, synchronize, labeled]
-  workflow_run:
-    workflows: ['Shipyard CI']
+  check_suite:
     types: [completed]
-
 permissions:
   contents: write
   pull-requests: write
-
 jobs:
   merge:
     if: >
-      (github.event_name == 'pull_request' &&
-       contains(join(github.event.pull_request.labels.*.name, ','), 'automerge'))
-      || (github.event_name == 'workflow_run' &&
-          github.event.workflow_run.conclusion == 'success' &&
-          github.event.workflow_run.event == 'pull_request')
+      (github.event_name == 'pull_request') ||
+      (github.event_name == 'check_suite' &&
+       github.event.check_suite.conclusion == 'success' &&
+       github.event.check_suite.pull_requests[0])
     runs-on: ubuntu-latest
     steps:
       - uses: peter-evans/auto-merge@v3
@@ -27,4 +22,4 @@ jobs:
           merge-method: squash
           commit-message: pull-request-title
           required-labels: automerge
-          pull-request: ${{ github.event.pull_request.url || github.event.workflow_run.pull_requests[0].url }}
+          pull-request-number: ${{ github.event.pull_request.number || github.event.check_suite.pull_requests[0].number }}

--- a/README.md
+++ b/README.md
@@ -49,6 +49,6 @@ Shipyard Bridge e2e test ✅
 
 Shipyard Bridge validation test #2 ✅
 
-## Auto-merge PRs
+## Auto-merge
 
-Add the `automerge` label to a pull request to enable the auto-merge workflow. Once the required checks, including Shipyard CI, finish successfully, the PR will be merged automatically using a squash commit titled with the pull request name.
+Add the `automerge` label to a pull request to enable the auto-merge workflow. Once the required checks finish successfully, the PR will be merged automatically using a squash commit titled with the pull request name.


### PR DESCRIPTION
## Summary
- replace the auto-merge workflow to trigger on pull requests and completed check suites
- configure peter-evans/auto-merge to squash merge PRs labeled automerge once checks succeed
- document the automerge label usage in the README

## Testing
- not run (workflow and documentation changes only)


------
https://chatgpt.com/codex/tasks/task_e_68ccae80285883338e94ee399bc753c1