### PR TITLE
Adjust auto-merge workflow to wait for CI success

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,19 +1,16 @@
 name: Auto-merge labeled PRs
 on:
-  pull_request:
-    types: [opened, reopened, synchronize, labeled]
-  check_suite:
+  workflow_run:
+    workflows: ['Shipyard CI']
     types: [completed]
+
 permissions:
   contents: write
   pull-requests: write
+
 jobs:
   merge:
-    if: >
-      (github.event_name == 'pull_request') ||
-      (github.event_name == 'check_suite' &&
-       github.event.check_suite.conclusion == 'success' &&
-       github.event.check_suite.pull_requests[0])
+    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.pull_requests[0]
     runs-on: ubuntu-latest
     steps:
       - uses: peter-evans/auto-merge@v3
@@ -22,4 +19,4 @@ jobs:
           merge-method: squash
           commit-message: pull-request-title
           required-labels: automerge
-          pull-request-number: ${{ github.event.pull_request.number || github.event.check_suite.pull_requests[0].number }}
+          pull-request-number: ${{ github.event.workflow_run.pull_requests[0].number }}


### PR DESCRIPTION
## Summary
- update the auto-merge workflow to trigger only after the "Shipyard CI" workflow completes successfully
- keep the existing automerge label requirement when invoking peter-evans/auto-merge

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68cd56b2b82483338efb076f9e10fc4f