### PR TITLE
Update brand color to blue

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -30,7 +30,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased text-black`}
       >
         <header className="p-4 text-xl font-semibold flex items-center justify-between bg-white">
-          <a href="/" className={"text-orange-500"}>Bloom — LIVE</a>
+          <a href="/" className={"text-blue-500"}>Bloom — LIVE</a>
           <Link
             href="/saved"
             className="text-sm font-normal text-slate-600 hover:text-slate-900 underline underline-offset-4"


### PR DESCRIPTION
## Summary
- switch the Bloom header link to use the blue brand color

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd576b99188333a32d5f499fe4b463