### PR TITLE
Update Respin button to Bloom orange

### DIFF
--- a/src/components/PromptBar.tsx
+++ b/src/components/PromptBar.tsx
@@ -161,7 +161,7 @@ export default function PromptBar({
               onClick={doAction}
               disabled={busy}
               aria-busy={busy ? "true" : "false"}
-              className="px-4 py-3 rounded-xl bg-red-500 text-white text-sm font-medium disabled:opacity-60"
+              className="px-4 py-3 rounded-xl bg-orange-500 hover:bg-orange-600 active:bg-orange-700 text-white text-sm font-medium disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
             >
               {buttonLabel}
             </button>


### PR DESCRIPTION
## Summary
- restyle the PromptBar Respin button to use Bloom brand orange tones
- ensure hover and active states stay within the orange palette and add an orange focus ring for accessibility

## Testing
- npm run lint *(fails: missing @eslint/eslintrc because dependencies cannot be installed without registry access)*

------
https://chatgpt.com/codex/tasks/task_e_68cd8567a4388333834d00693bb98996