### PR TITLE
Update header brand color

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -30,7 +30,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased text-black`}
       >
         <header className="p-4 text-xl font-semibold flex items-center justify-between bg-white">
-          <a href="/" className={"text-pink-500"}>The Bloom 100</a>
+          <a href="/" className={"text-orange-500"}>The Bloom 100</a>
           <Link
             href="/saved"
             className="text-sm font-normal text-slate-600 hover:text-slate-900 underline underline-offset-4"


### PR DESCRIPTION
## Summary
- change the header brand link to use the orange text utility class

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d04134eb548333b8b09f0362d52e23