### PR TITLE
feat: load curated daily feed with fallback

### DIFF
--- a/public/daily/today.json
+++ b/public/daily/today.json
@@ -1,0 +1,113 @@
+{
+  "date": "2025-09-21",
+  "items": [
+    {
+      "id": "dQw4w9WgXcQ",
+      "title": "Rick Astley - Never Gonna Give You Up (Official Music Video)",
+      "source": "youtube",
+      "url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      "thumb": "https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg",
+      "duration": "3:33",
+      "rank": 1
+    },
+    {
+      "id": "9bZkp7q19f0",
+      "title": "PSY - GANGNAM STYLE(\uac15\ub0a8\uc2a4\ud0c0\uc77c) M/V",
+      "source": "youtube",
+      "url": "https://www.youtube.com/watch?v=9bZkp7q19f0",
+      "thumb": "https://i.ytimg.com/vi/9bZkp7q19f0/hqdefault.jpg",
+      "duration": "4:13",
+      "rank": 2
+    },
+    {
+      "id": "3JZ_D3ELwOQ",
+      "title": "Mark Ronson - Uptown Funk (Official Video) ft. Bruno Mars",
+      "source": "youtube",
+      "url": "https://www.youtube.com/watch?v=3JZ_D3ELwOQ",
+      "thumb": "https://i.ytimg.com/vi/3JZ_D3ELwOQ/hqdefault.jpg",
+      "duration": "4:30",
+      "rank": 3
+    },
+    {
+      "id": "L_jWHffIx5E",
+      "title": "a-ha - Take On Me (Official Video) [Remastered in 4K]",
+      "source": "youtube",
+      "url": "https://www.youtube.com/watch?v=L_jWHffIx5E",
+      "thumb": "https://i.ytimg.com/vi/L_jWHffIx5E/hqdefault.jpg",
+      "duration": "4:04",
+      "rank": 4
+    },
+    {
+      "id": "fJ9rUzIMcZQ",
+      "title": "Queen – Bohemian Rhapsody (Official Video Remastered)",
+      "source": "youtube",
+      "url": "https://www.youtube.com/watch?v=fJ9rUzIMcZQ",
+      "thumb": "https://i.ytimg.com/vi/fJ9rUzIMcZQ/hqdefault.jpg",
+      "duration": "6:00",
+      "rank": 5
+    },
+    {
+      "id": "kXYiU_JCYtU",
+      "title": "Numb (Official Music Video) [4K UPGRADE] – Linkin Park",
+      "source": "youtube",
+      "url": "https://www.youtube.com/watch?v=kXYiU_JCYtU",
+      "thumb": "https://i.ytimg.com/vi/kXYiU_JCYtU/hqdefault.jpg",
+      "duration": "3:07",
+      "rank": 6
+    },
+    {
+      "id": "4NRXx6U8ABQ",
+      "title": "The Weeknd - Blinding Lights (Official Video)",
+      "source": "youtube",
+      "url": "https://www.youtube.com/watch?v=4NRXx6U8ABQ",
+      "thumb": "https://i.ytimg.com/vi/4NRXx6U8ABQ/hqdefault.jpg",
+      "duration": "4:23",
+      "rank": 7
+    },
+    {
+      "id": "2Vv-BfVoq4g",
+      "title": "Ed Sheeran - Perfect (Official Music Video)",
+      "source": "youtube",
+      "url": "https://www.youtube.com/watch?v=2Vv-BfVoq4g",
+      "thumb": "https://i.ytimg.com/vi/2Vv-BfVoq4g/hqdefault.jpg",
+      "duration": "4:40",
+      "rank": 8
+    },
+    {
+      "id": "uelHwf8o7_U",
+      "title": "Eminem - Love The Way You Lie ft. Rihanna",
+      "source": "youtube",
+      "url": "https://www.youtube.com/watch?v=uelHwf8o7_U",
+      "thumb": "https://i.ytimg.com/vi/uelHwf8o7_U/hqdefault.jpg",
+      "duration": "4:27",
+      "rank": 9
+    },
+    {
+      "id": "RgKAFK5djSk",
+      "title": "Wiz Khalifa - See You Again ft. Charlie Puth [Official Video] Furious 7 Soundtrack",
+      "source": "youtube",
+      "url": "https://www.youtube.com/watch?v=RgKAFK5djSk",
+      "thumb": "https://i.ytimg.com/vi/RgKAFK5djSk/hqdefault.jpg",
+      "duration": "3:58",
+      "rank": 10
+    },
+    {
+      "id": "ktvTqknDobU",
+      "title": "Imagine Dragons - Radioactive",
+      "source": "youtube",
+      "url": "https://www.youtube.com/watch?v=ktvTqknDobU",
+      "thumb": "https://i.ytimg.com/vi/ktvTqknDobU/hqdefault.jpg",
+      "duration": "3:47",
+      "rank": 11
+    },
+    {
+      "id": "YykjpeuMNEk",
+      "title": "Coldplay - Hymn For The Weekend (Official Video)",
+      "source": "youtube",
+      "url": "https://www.youtube.com/watch?v=YykjpeuMNEk",
+      "thumb": "https://i.ytimg.com/vi/YykjpeuMNEk/hqdefault.jpg",
+      "duration": "4:21",
+      "rank": 12
+    }
+  ]
+}

--- a/src/lib/fetchDaily.ts
+++ b/src/lib/fetchDaily.ts
@@ -1,0 +1,67 @@
+export interface DailyItem {
+  id: string;
+  title: string;
+  source: "youtube";
+  url: string;
+  thumb: string;
+  duration?: string;
+  rank?: number;
+}
+
+export interface DailyPayload {
+  date: string;
+  items: DailyItem[];
+}
+
+// Tests are intentionally skipped for now because this project does not ship with a test runner.
+export class DailyNotFoundError extends Error {
+  previousDate?: string;
+
+  constructor(previousDate?: string) {
+    super("Daily feed not found");
+    this.name = "DailyNotFoundError";
+    this.previousDate = previousDate;
+  }
+}
+
+function formatDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, "0");
+  const day = `${date.getDate()}`.padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+async function parseResponse(
+  response: Response,
+  fallbackDate: string,
+): Promise<DailyPayload> {
+  const data = await response
+    .json()
+    .catch(() => ({ date: fallbackDate, items: [] }));
+  const date = typeof data?.date === "string" ? data.date : fallbackDate;
+  const items = Array.isArray(data?.items) ? data.items : [];
+  return { date, items };
+}
+
+export async function getDaily(): Promise<DailyPayload> {
+  const today = new Date();
+  const fallbackDate = formatDate(new Date(today.getTime() - 24 * 60 * 60 * 1000));
+
+  const todayResponse = await fetch("/daily/today.json", {
+    cache: "no-store",
+  }).catch(() => undefined);
+
+  if (todayResponse?.ok) {
+    return parseResponse(todayResponse, formatDate(today));
+  }
+
+  const fallbackResponse = await fetch(`/daily/${fallbackDate}.json`, {
+    cache: "no-store",
+  }).catch(() => undefined);
+
+  if (fallbackResponse?.ok) {
+    return parseResponse(fallbackResponse, fallbackDate);
+  }
+
+  throw new DailyNotFoundError(fallbackDate);
+}


### PR DESCRIPTION
## Summary
- add a typed daily feed loader with fallback to yesterday's JSON when today is missing
- refactor the home page to consume cached daily items, surface friendly fallback messaging, and hide the old quota banner when data exists
- seed a `public/daily/today.json` file with 12 demo items so the curated list renders immediately

## Testing
- npm run lint *(fails: missing dependencies because the registry blocks installing openai)*

------
https://chatgpt.com/codex/tasks/task_e_68d0477c3eb88333902f61d9488440d5