### PR TITLE
Fix build and update brand link color

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -30,7 +30,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased text-black`}
       >
         <header className="p-4 text-xl font-semibold flex items-center justify-between bg-white">
-          <a href="/" className={"text-pink-500"}>The Bloom 100</a>
+          <a href="/" className={"text-orange-500"}>The Bloom 100</a>
           <Link
             href="/saved"
             className="text-sm font-normal text-slate-600 hover:text-slate-900 underline underline-offset-4"


### PR DESCRIPTION
## Summary
- switch the brand link text color class from pink to orange to satisfy the design request

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3029739c4833382c96596aceb7ea7