### PR TITLE
Update Respin button accent color

### DIFF
--- a/src/app/components/NowPlaying.tsx
+++ b/src/app/components/NowPlaying.tsx
@@ -274,7 +274,7 @@ function RespinButton({
             onClick={onClick}
             disabled={loading}
             aria-busy={loading ? "true" : "false"}
-            className="px-4 py-3 rounded-xl bg-pink-500 hover:bg-pink-600 active:bg-pink-700 text-white text-sm font-medium disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pink-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+            className="px-4 py-3 rounded-xl bg-orange-500 hover:bg-orange-600 active:bg-orange-700 text-white text-sm font-medium disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
           >
             {loading ? "Searching…" : "Respin"}
           </button>


### PR DESCRIPTION
## Summary
- switch the Respin button styling from the pink accent to the orange variant to match the latest brand direction

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d306ddc6a88333bed9d50ff28cddae