### PR TITLE
shipyard: Header link → red (SafeReplace)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -30,7 +30,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased text-black`}
       >
         <header className="p-4 text-xl font-semibold flex items-center justify-between bg-white">
-          <a href="/" className={"text-purple-500"}>The Bloom 100</a>
+          <a href="/" className={"text-red-500"}>The Bloom 100</a>
           <Link
             href="/saved"
             className="text-sm font-normal text-slate-600 hover:text-slate-900 underline underline-offset-4"


### PR DESCRIPTION
## Ticket
```yaml
title: Header link → red (SafeReplace)
why: Second deterministic smoke.
scope:
  - src/app/layout.tsx
safe_replace:
  - path: src/app/layout.tsx
    replacements:
      - find: text-purple-500
        replace: text-red-500
      - find: hover:text-purple-600
        replace: hover:text-red-600
      - find: text-orange-500
        replace: text-red-500
      - find: hover:text-orange-600
        replace: hover:text-red-600
dod:
  - Literal replacements only; return full file.
guardrails:
  - No other edits.
```