### PR TITLE
shipyard: Header link → purple (from green) (SafeReplace)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -30,7 +30,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased text-black`}
       >
         <header className="p-4 text-xl font-semibold flex items-center justify-between bg-white">
-          <a href="/" className={"text-green-500"}>The Bloom 100</a>
+          <a href="/" className={"text-purple-500"}>The Bloom 100</a>
           <Link
             href="/saved"
             className="text-sm font-normal text-slate-600 hover:text-slate-900 underline underline-offset-4"


### PR DESCRIPTION
## Ticket
```yaml
title: Header link → purple (from green) (SafeReplace)
why: Flip header back to purple.
scope:
  - src/app/layout.tsx
safe_replace:
  - path: src/app/layout.tsx
    replacements:
      - find: text-green-500
        replace: text-purple-500
      - find: hover:text-green-600
        replace: hover:text-purple-600
dod:
  - Literal replacements only; return full file.
guardrails:
  - No other edits.
```